### PR TITLE
Accessibility Suggestion

### DIFF
--- a/chrome/components/ogx_UC-newtabpage.css
+++ b/chrome/components/ogx_UC-newtabpage.css
@@ -250,7 +250,7 @@ input:focus-visible, input:focus-visible{
 
 .search-wrapper{ 
     border-radius: 0px !important;
-    outline: none !important;
+    outline-color: transparent !important;
     box-shadow: none !important;
     }
     
@@ -276,7 +276,7 @@ input:focus-visible, input:focus-visible{
     
 .search-wrapper .search-inner-wrapper:active input, .search-wrapper input:focus {
     /*outline: 1px solid var(--button-active-bgcolor) !important;*/
-    outline: none !important;
+    outline-color: transparent !important;
     border-color: transparent !important;
     /*margin-left: 1px !important;
     /*z-index: 1 !important;*/

--- a/chrome/components/ogx_button-styles.css
+++ b/chrome/components/ogx_button-styles.css
@@ -83,7 +83,7 @@ panel menulist:hover, panel menulist[open] {
 
 treechildren::-moz-tree-row(selected) {
     background-color: var(--button-active-bgcolor) !important;
-    outline: none !important;
+    outline-color: transparent !important;
 }
 
 treechildren::-moz-tree-image(selected), treechildren::-moz-tree-twisty(selected), treechildren::-moz-tree-cell-text(selected) {

--- a/chrome/components/ogx_tab-shapes.css
+++ b/chrome/components/ogx_tab-shapes.css
@@ -115,7 +115,7 @@ tab:is([pinned]) .tab-context-line {
     border-radius: 0px !important;
   }
   .tab-background[multiselected="true"]{
-      outline: none !important;
+      outline-color: transparent !important;
   }
 
 /* ########################################## Selected Tab - Box Shadow ########################################## */

--- a/chrome/components/ogx_tabs-bar.css
+++ b/chrome/components/ogx_tabs-bar.css
@@ -117,12 +117,12 @@
     .tabbrowser-tab:is([multiselected]):not([selected]) .tab-stack {
         background: var(--button-hover-bgcolor) !important;
         clip-path: polygon(5px 0%, 200% 0%, 0% 200%, 0% 5px);
-        outline: none !important;
+        outline-color: transparent !important;
     }
     
     .tab-background[multiselected]:not([selected]) {
         background: transparent !important;
-        outline: none !important;
+        outline-color: transparent !important;
     }
 
     .tab-background[multiselected][selected] {
@@ -257,7 +257,7 @@ toolbar:is(#TabsToolbar) #firefox-view-button .toolbarbutton-icon {
 }
 
 toolbar:is(#TabsToolbar) #firefox-view-button[aria-pressed="true"] .toolbarbutton-icon {
-    outline: none !important;
+    outline-color: transparent !important;
     background: var(--button-hover-bgcolor) !important;
     fill: var(--arrowpanel-color, var(--lwt-tab-text)) !important;
 }


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8