### PR TITLE
Added icon support for another popular spotify extension.

### DIFF
--- a/chrome/components/ogx_left-sidebar.css
+++ b/chrome/components/ogx_left-sidebar.css
@@ -318,6 +318,7 @@ toolbaritem toolbarbutton[badge="0"]:not(:hover) .toolbarbutton-badge { opacity:
     
 /* Spotify Extension */
 #PersonalToolbar #sidebarspotyplay_godie-BAP{ list-style-image: url("../icons/logo_spotify.svg") !important; }
+#PersonalToolbar #_1d0f1bc6-5e9c-4450-aef5-75cefb44660f_-BAP{ list-style-image: url("../icons/logo_spotify.svg") !important; }
 
 /* Telegram Extension */
 #PersonalToolbar #_14390478-b41b-4e29-8307-8a3c714f7783_-BAP{ list-style-image: url("../icons/logo_telegram.svg") !important; }


### PR DESCRIPTION
This extension is very minimalistic and let you control spotify without actually having to change tab. A bit like how OGX does when you hover over the play button. Link here :
https://addons.mozilla.org/fr/firefox/addon/spotify-player/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=search