### PR TITLE
Update background size properties to use 'cover' for better image sca…

### DIFF
--- a/Extras/TreeStyle-tabs/README.md
+++ b/Extras/TreeStyle-tabs/README.md
@@ -10,6 +10,12 @@
     <td width="500px">firefoxgx.verticalTabs-expandOnHover</td>
     <td width="50px">true</td></tr>
     </table>
+
+<li>Note: When using the 'Expand on hover' feature, and are using main image and want the image underneath the tabs to match with the rest of the window you must enable legacy main image scaling in about:config page:</li>
+    <table><tr>
+    <td width="500px">firefoxgx.use-legacy-main-image-scaling</td>
+    <td width="50px">true</td></tr>
+    </table>
 <li>Dependig of the extension you will use for tree-tabs you have different steps to follow:
 <ul><li><a href="https://github.com/Godiesc/firefox-gx/tree/main/Extras/TreeStyle-tabs/Sidebery">Sideberry</a></li>
 <li><a href="https://github.com/Godiesc/firefox-gx/tree/main/Extras/TreeStyle-tabs/Tab-Center-Reborn">Tab-center-reborn</a></li>

--- a/Extras/TreeStyle-tabs/README.md
+++ b/Extras/TreeStyle-tabs/README.md
@@ -11,9 +11,9 @@
     <td width="50px">true</td></tr>
     </table>
 
-<li>Note: When using the 'Expand on hover' feature, and are using main image and want the image underneath the tabs to match with the rest of the window you must enable legacy main image scaling in about:config page:</li>
+<li>Note: When using the 'Expand on hover' feature, and are using main image and want the image on the vertical tabs to match with the rest of the window you must enable 'main image expand on hover aligned' in about:config page:</li>
     <table><tr>
-    <td width="500px">firefoxgx.use-legacy-main-image-scaling</td>
+    <td width="500px">firefoxgx.main-image-expandOnHover-aligned</td>
     <td width="50px">true</td></tr>
     </table>
 <li>Dependig of the extension you will use for tree-tabs you have different steps to follow:

--- a/chrome/components/ogx_main-image.css
+++ b/chrome/components/ogx_main-image.css
@@ -58,7 +58,7 @@
    /* Set the main image to all body */
    
    #main-window {
-      background-size: 100% 100vh !important;
+      background-size: cover !important;
    }
    
    /* blur effect 
@@ -84,13 +84,13 @@
    /* Align tab-background image */
 
    .tabbrowser-tab:is([visuallyselected],[multiselected]) .tab-background {
-      background-size: 100% 100vh !important;
+      background-size: cover !important;
    }
 
    /* Improved background when moving tab */
 
    #tabbrowser-tabs:is([movingtab]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab > .tab-stack  > .tab-background{
-      background-size: 100vw 100vh !important;
+      background-size: cover !important;
    }
 
    /* I override url-bar 'focus' from ogx_urlbar-searchbar.css */
@@ -110,7 +110,7 @@
    #statuspanel label, 
    findbar{
       background-image: var(--lwt-main-image) !important;
-      background-size: 100vw 100vh !important;
+      background-size: cover !important;
       background-position: calc(0px - var(--my-vertical-toolbar-width)) bottom !important;
       background-attachment: fixed !important;
       border-color: var(--my-content-border-color) !important;
@@ -125,7 +125,7 @@
       :root[sidebar-expand-on-hover]:not([chromehidden~="toolbar"]) {
          #sidebar-main {
             background-image: var(--lwt-additional-images), var(--lwt-header-image) !important;
-            background-size: 100vw 100vh !important;
+            background-size: cover !important;
             background-position-y: bottom !important;
             
             &[sidebar-positionend] {
@@ -173,7 +173,7 @@
                #sidebar-main {
                   background-image: var(--lwt-additional-images), var(--lwt-header-image) !important;
                   background-position-y: bottom !important;
-                  background-size: 100vw 100vh !important;
+                  background-size: cover !important;
 
                   &[positionend] {
                      background-image: linear-gradient(var(--toolbar-bgcolor), var(--toolbar-bgcolor)),
@@ -212,7 +212,7 @@
                 
                 .tabbrowser-tab:is([visuallyselected],[multiselected])  .tab-background::before,
                 .tabbrowser-tab:is([visuallyselected],[multiselected])  .tab-background::after {
-                   background-size: 100% !important;
+                   background-size: cover !important;
                 }
       }
    }

--- a/chrome/components/ogx_main-image.css
+++ b/chrome/components/ogx_main-image.css
@@ -217,9 +217,9 @@
       }
    }
    
-   /* ______________________ Legacy image scaling ______________________ */
+   /* ______________________ Main image expand on hover alignment ______________________ */
 
-   @media -moz-pref("firefoxgx.use-legacy-main-image-scaling") {
+   @media -moz-pref("firefoxgx.main-image-expandOnHover-aligned") {
 
       #main-window {
          background-size: 100% 100vh !important;

--- a/chrome/components/ogx_main-image.css
+++ b/chrome/components/ogx_main-image.css
@@ -217,6 +217,64 @@
       }
    }
    
+   /* ______________________ Legacy image scaling ______________________ */
+
+   @media -moz-pref("firefoxgx.use-legacy-main-image-scaling") {
+
+      #main-window {
+         background-size: 100% 100vh !important;
+      }
+
+      .tabbrowser-tab:is([visuallyselected],[multiselected]) .tab-background {
+         background-size: 100% 100vh !important;
+      }
+
+      #tabbrowser-tabs:is([movingtab]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab > .tab-stack  > .tab-background {
+         background-size: 100vw 100vh !important;
+      }
+
+      #statuspanel label, 
+      findbar {
+         background-size: 100vw 100vh !important;
+      }
+
+      @media -moz-pref("sidebar.verticalTabs") {
+
+         :root[sidebar-expand-on-hover]:not([chromehidden~="toolbar"]) {
+            #sidebar-main {
+               background-size: 100vw 100vh !important;
+            }
+         }
+
+         @media -moz-pref("firefoxgx.verticalTabs-expandOnHover") {
+
+            @media -moz-pref("firefoxgx.left-sidebar") {
+
+               :root[sidebar-expand-on-hover]:not([chromehidden~="toolbar"]) {
+                  #sidebar-main {
+                     background-size: 100vw 100vh !important;
+                  }
+               }
+            }
+         }
+      }
+
+      @media -moz-pref("firefoxgx.tab-shapes") {
+
+         @media -moz-pref("userChrome.tab.bottom_rounded_corner.wave") or 
+                -moz-pref("userChrome.tab.bottom_rounded_corner.australis") or 
+                -moz-pref("userChrome.tab.bottom_rounded_corner.chrome_legacy") or 
+                -moz-pref("userChrome.tab.bottom_rounded_corner.chrome") or 
+                -moz-pref("userChrome.tab.bottom_rounded_corner.edge") {
+
+                  .tabbrowser-tab:is([visuallyselected],[multiselected]) .tab-background::before,
+                  .tabbrowser-tab:is([visuallyselected],[multiselected]) .tab-background::after {
+                     background-size: 100% !important;
+                  }
+         }
+      }
+   }
+
    /* Oneline compatibility */
 
    @media -moz-pref("firefoxgx.oneline") {


### PR DESCRIPTION
I updated the background code to use cover instead of vh and wh so that when you resize the window the main image does not get stretched.

Here is a direct comparison
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/ea77289f-3ad0-4083-8412-297d1d7ecb3a" />

On the left is the current code with the bad stretching and on right is the significantly better looking covered image

Love your work on Firefox GX btw apart from this everything in the theme looks so good!